### PR TITLE
Fixes bad position of overlay on iPhone X

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -50,7 +50,6 @@ body.fl-with-top-menu {
 .onboarding-content {
   position: absolute;
   top: 0;
-  top: env(safe-area-inset-top);
   left: 0;
   right: 0;
   bottom: 0;


### PR DESCRIPTION
Removes iPhone X CSS instruction to add a `top` compensation for dark overlay. Unnecessary because the parent container already has it.