### PR TITLE
show default slide or image when adding another slide 4196

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -1,23 +1,23 @@
 var container = $('[data-onboarding-id]');
-var id = $(container).data('onboarding-id');
+var id = $('.fl-widget-instance').data('id');
+var sliderId = $(container).data('onboarding-id');
 var uuid = Fliplet.Widget.getUUID(id);
 var config = Fliplet.Widget.getData(id);
 var pvKey = 'fl-onboarding-layout-' + uuid;
 var delayTime = config.delaySlides ? config.delaySlides * 1000 : 3000;
 
 var initOnboarding = function () {
-  var swiperElement = $(container).find('.swiper-container');
-  var swiper = new Swiper( swiperElement, {
+  var swiper = new Swiper( '.swiper-container', {
     direction: 'horizontal',
     loop: false,
     autoHeight: true,
-    pagination: '.swiper-pagination-' + id,
+    pagination: '.swiper-pagination-' + sliderId,
     paginationClickable: true,
-    nextButton: '.swiper-button-next-' + id,
-    prevButton: '.swiper-button-prev-' + id,
+    nextButton: '.swiper-button-next-' + sliderId,
+    prevButton: '.swiper-button-prev-' + sliderId,
     grabCursor: true
   });
-  $(container).removeClass('loading');
+  $('.onboarding-holder').removeClass('loading');
 
   swiper.update();
 


### PR DESCRIPTION
@squallstar @tonytlwu 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/4196
## Description
Changed functionality of onboarding widget to show default slide or image after adding it into slider via adding another id to slider and solved the problem with error when add onboardig widget to application.
## Screenshots/screencasts
![Screen Shot 2019-09-06 at 14 55 52](https://user-images.githubusercontent.com/52824216/64426148-7d84ef00-d0b6-11e9-932c-adfcdebac827.png)
https://cl.ly/bcd1e4d7f46c
## Backward compatibility
This change is fully backward compatible.