### PR TITLE
"Select an animation" field now is not cropped in the "Slider options" tab

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -14,7 +14,7 @@ body {
   border: 0;
   width: 100%;
   background-color: transparent;
-  padding: 15px;
+  padding-top: 15px;
 }
 
 .add-link .fl-widget-provider {


### PR DESCRIPTION
@tonytlwu @squallstar 

## Issue
Fliplet/fliplet-studio#5076

## Description
Fixed padding.

## Screenshots/screencasts
<img width="381" alt="onboarding demo" src="https://user-images.githubusercontent.com/52824207/66998720-6e458800-f0dd-11e9-8310-2515db709cc7.png">

## Backward compatibility
This change is fully backward compatible.