### PR TITLE
Placeholder in IE now will display as placeholder not a default value

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -309,7 +309,7 @@
               <label for="list-item-desc-\{{id}}">Description</label>
             </div>
             <div class="col-sm-8">
-              <textarea class="form-control list-item-desc" id="list-item-desc-\{{id}}" name="list-item-desc-\{{id}}" placeholder="Enter description" rows="3"></textarea>
+              <textarea class="form-control list-item-desc" id="list-item-desc-\{{id}}" name="list-item-desc-\{{id}}" rows="3"></textarea>
             </div>
           </div>
 

--- a/js/interface.js
+++ b/js/interface.js
@@ -446,6 +446,7 @@ var FlSlider = (function() {
       var $newPanel = $(Handlebars.panelTemplate(data));
       $accordionContainer.append($newPanel);
 
+      $newPanel.find('.form-control.list-item-desc').attr('placeholder', 'Enter description');
       $newPanel.find('.form-control:eq(0)').select();
       $('form.form-horizontal').stop().animate({
         scrollTop: $('.tab-content').height()


### PR DESCRIPTION
@sofiiakvasnevska 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/5060

## Description
Placeholder in IE now will display as a placeholder, not a default value

## Screenshots/screencasts
![onboarding-5060](https://user-images.githubusercontent.com/53430352/68869950-b10d7680-0702-11ea-8260-2308f0743537.gif)


## Backward compatibility

This change is fully backward compatible.

## Notes
Same as in this [PR](https://github.com/Fliplet/fliplet-widget-slider/pull/19)