### PR TITLE
Current page is not added to link provider dropdown

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -262,6 +262,7 @@ var FlSlider = (function() {
       data.skipLinkAction = $.extend(true, {
         action: 'screen',
         page: '',
+        omitPages: omitPages,
         transition: 'fade',
         options: {
           hideAction: true


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/4498

## Description
Added omit pages property for onboarding skip button.

## Backward compatibility
This change is fully backward compatible.
