### PR TITLE
Current page is not added to link provider dropdown 

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -303,6 +303,7 @@ var FlSlider = (function() {
       data.seenLinkAction = $.extend(true, {
         action: 'screen',
         page: '',
+        omitPages: omitPages,
         transition: 'fade',
         options: {
           hideAction: true


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/4498

## Description
Added omit page in Only show to first time users section.

## Backward compatibility
This change is fully backward compatible.