### PR TITLE
Reverted changes

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -32,8 +32,8 @@ html.web[data-has-notch] body,
 	right: 0;
 	bottom: 0;
 	left: 0;
-  opacity: 1;
-  transition: opacity 0.2s ease-out;
+	opacity: 1;
+	transition: opacity 0.2s ease-out;
 }
 
 .onboarding-wrapper {

--- a/css/build.css
+++ b/css/build.css
@@ -15,9 +15,7 @@ html.web[data-has-notch] body,
 /* Screen Defaults */
 
 .mode-interact .fl-widget-instance[data-name="Onboarding Slides"] {
-	position: relative;
-	width: 100%;
-	height: 100vh;
+	position: static;
 }
 
 /* ONBOARDING */
@@ -29,6 +27,11 @@ html.web[data-has-notch] body,
 	background-position: center center;
 	background-size: cover;
 	background-repeat: no-repeat;
+	position: absolute;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
   opacity: 1;
   transition: opacity 0.2s ease-out;
 }


### PR DESCRIPTION
Previous changes were made based on a flawed `page.css` from `fliplet-pages`.
It is now safe to revert to the original settings.

This was tested locally on an app with and without the new drag and drop system.

Issue ref: https://github.com/Fliplet/fliplet-studio/issues/5398