### PR TITLE
Users now cannot save onboarding settings without selecting a screen 

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -261,7 +261,7 @@ var FlSlider = (function() {
 
       data.skipLinkAction = $.extend(true, {
         action: 'screen',
-        page: '',
+        page: 'none',
         omitPages: omitPages,
         transition: 'fade',
         options: {
@@ -302,7 +302,7 @@ var FlSlider = (function() {
 
       data.seenLinkAction = $.extend(true, {
         action: 'screen',
-        page: '',
+        page: 'none',
         omitPages: omitPages,
         transition: 'fade',
         options: {
@@ -327,6 +327,13 @@ var FlSlider = (function() {
       });
 
       skipSeenLinkActionProvider.then(function(result) {
+        if (data.skipSeenEnabled && (!result.data.page || result.data.page === 'none')) {
+          Fliplet.Modal.alert({
+            message: 'Please configure a screen to redirect to.'
+          });
+          return Promise.reject();
+        }
+
         data.seenLinkAction = result && result.data.action !== 'none' ? result.data : null;
         return Promise.resolve();
       });


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/3701

## Description
If the screen is not selected provider promise is rejected.

## Screenshots/screencasts
![onboarding](https://user-images.githubusercontent.com/52824207/73639599-618d7580-4675-11ea-9796-643485b8904c.gif)

## Backward compatibility
This change is fully backward compatible.