### PR TITLE
Onboarding now works correctly in old dnd

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -165,7 +165,7 @@ var FlSlider = (function() {
     },
 
     loadFullscreenImage: function() {
-      if (typeof data.fullImageConfig !== 'undefined' || data.fullImageConfig !== null) {
+      if (data.fullImageConfig) {
         $('.background-image .set-bg-image').text('Replace image');
         $('.background-image .thumb-holder').removeClass('hidden');
         $('.background-image .thumb-image img').attr('src', data.fullImageConfig.url);


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5858

## Description
Old dnd onboarding does not have a background image, therefore check for URL failed. Fixed if statement.

## Screenshots/screencasts
https://streamable.com/t3aoeh

## Backward compatibility
This change is fully backward compatible.